### PR TITLE
fping: Add package

### DIFF
--- a/net/fping/Makefile
+++ b/net/fping/Makefile
@@ -45,8 +45,8 @@ CONFIGURE_ARGS+= \
 	--enable-ipv6
 
 define Package/fping/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/sbin/{fping,fping6} $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/opt/bin
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/opt/sbin/{fping,fping6} $(1)/opt/bin/
 endef
 
 $(eval $(call BuildPackage,fping))


### PR DESCRIPTION
Compile tested: armv5, armv7
Run tested: armv5, armv7

@zyxmon if you could enable this package in the armv5 and armv7 repos that would be great.

Also, any chance you can enable the "aggregate" package as well?  I added it upstream to openwrt and it looks like it's already compiling and working in entware (I tested on arm5/arm7)

Thanks!