### PR TITLE
ifstat: Add package

### DIFF
--- a/net/ifstat/Makefile
+++ b/net/ifstat/Makefile
@@ -21,12 +21,14 @@ PKG_LICENSE_FILES:=COPYING
 
 include $(INCLUDE_DIR)/package.mk
 
+CONFIGURE_ARGS += \
+	--without-snmp
+
 define Package/ifstat
   SECTION:=net
   CATEGORY:=Network
   TITLE:=InterFace STATistics Monitoring
   URL:=http://gael.roualland.free.fr/ifstat/
-  DEPENDS:=+libnetsnmp
 endef
 
 define Package/ifstat/description
@@ -37,8 +39,8 @@ define Package/ifstat/description
 endef
 
 define Package/ifstat/install
-	$(INSTALL_DIR) $(1)/usr/bin
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ifstat $(1)/usr/bin/
+	$(INSTALL_DIR) $(1)/opt/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ifstat $(1)/opt/bin/
 endef
 
 $(eval $(call BuildPackage,ifstat))


### PR DESCRIPTION
Compile tested: armv5, armv7
Run tested: armv5, armv7

Linking to net-snmp seems to force the compiled binary to be dynamically
linked to the wrong ld-linux.so. I've disabled net-snmp support until I
can figure out why.

@zyxmon Please enable in the armv5 and armv7 repos - thanks!