### PR TITLE
glib: fix gdbus socket file path

### DIFF
--- a/libs/glib2/patches/601-dbus-socket-path.patch
+++ b/libs/glib2/patches/601-dbus-socket-path.patch
@@ -1,0 +1,11 @@
+--- a/gio/gdbusaddress.c
++++ b/gio/gdbusaddress.c
+@@ -1601,7 +1601,7 @@
+       ret = g_strdup (g_getenv ("DBUS_SYSTEM_BUS_ADDRESS"));
+       if (ret == NULL)
+         {
+-          ret = g_strdup ("unix:path=/var/run/dbus/system_bus_socket");
++          ret = g_strdup ("unix:path=/opt/var/run/dbus/system_bus_socket");
+         }
+       break;
+ 


### PR DESCRIPTION
gdbus based application can not connect to system bus

Compile tested: x86_64 on archlinux
Run tested: armv7 netgear r6300v2 (BCM 4708)
