### PR TITLE
perl-image-exiftool: Upgraded exiftool to v10.51

### DIFF
--- a/lang/perl-image-exiftool/Makefile
+++ b/lang/perl-image-exiftool/Makefile
@@ -8,12 +8,12 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=perl-image-exiftool
-PKG_VERSION:=10.08
+PKG_VERSION:=10.51
 PKG_RELEASE:=1
 
 PKG_SOURCE_URL:=http://www.sno.phy.queensu.ca/~phil/exiftool
 PKG_SOURCE:=Image-ExifTool-$(PKG_VERSION).tar.gz
-PKG_MD5SUM:=392026e36db9111a60bf9ac91d4901cf
+PKG_MD5SUM:=9a400a6c66caa75789d0be6722723672
 
 PKG_LICENSE:=GPL-1.0+ Artistic-1.0-Perl
 


### PR DESCRIPTION
Upgraded the exiftool package to v10.51

I ran without any errors the following command:

`make package/perl-image-exiftool/compile`
