### PR TITLE
- updated gcc build in order to not be necessary to run at every buil…

### DIFF
--- a/devel/gcc/Makefile
+++ b/devel/gcc/Makefile
@@ -114,6 +114,7 @@ define Build/Configure
 			--enable-target-optspace \
 			--with-gnu-ld \
 			--with-stage1-ldflags="-Wl,-rpath=/opt/lib -Wl,--dynamic-linker=/opt/lib/$(DYNLINKER)" \
+			--with-specs="-Wl,-rpath=/opt/lib -Wl,--dynamic-linker=/opt/lib/$(DYNLINKER)" \
 			--with-boot-ldflags="static-libstdc++ -static-libgcc -Wl,-rpath=/opt/lib -Wl,--dynamic-linker=/opt/lib/$(DYNLINKER)" \
 			--disable-nls \
 			--disable-libsanitizer \

--- a/net/apache/Makefile
+++ b/net/apache/Makefile
@@ -40,7 +40,7 @@ endef
 
 define Package/apache
 $(call Package/apache/Default)
-  DEPENDS:=+libapr +libaprutil +libpcre +libopenssl +unixodbc +zlib
+  DEPENDS:=+libapr +libaprutil +libpcre +libopenssl +unixodbc +zlib +libxml2
 endef
 
 define Package/apache/description
@@ -77,6 +77,9 @@ $(call Package/apache/Default/description)
  .
  This package contains the icons from Apache.
 endef
+
+CONFIGURE_VARS += \
+	ac_cv_gcc__std_c89=no
 
 TARGET_CFLAGS += $(FPIC)
 TARGET_CPPFLAGS += -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE


### PR DESCRIPTION
…d 'source /opt/bin/gcc_env.sh'

cat /opt/bin/gcc_env.sh

export LDFLAGS="-Wl,-rpath=/opt/lib -Wl,--dynamic-linker=/opt/lib/ld-uClibc.so.0 -L/opt/lib"

This is a mirror of [openwrt/package](https://github.com/openwrt/packages) feed, so making PR there is the best way to contribute. New package will arrive to Entware-ng in the next month.

Please double check that your PR is for appropriate feed:
- [rtndev](https://github.com/Entware-ng/rtndev) for packages which was never existed in OpenWrt before.
- [go](https://github.com/Entware-ng/entware-go) for new packages in Golang.
- [oldports](https://github.com/Entware-ng/entware-oldpackages-ports) for packages which is abandoned form OpenWrt for some reason.
- [packages](https://github.com/Entware-ng/entware-packages), [routing](https://github.com/Entware-ng/entware-routing), [telephony](https://github.com/Entware-ng/entware-telephony) for packages, maintained by OpenWrt team.

Please double check that your commits:
- all start with "<package name>: "

Thanks for your contribution
Please remove this text (before ---) and fill the following template
-------------------------------

Compile tested: (put here arch, model, version)
Run tested: (put here arch, model, version, tests done)
