### PR TITLE
mpd: disable epoll signalfd and eventfd

### DIFF
--- a/sound/mpd/Makefile
+++ b/sound/mpd/Makefile
@@ -156,7 +156,10 @@ CONFIGURE_ARGS += \
 	--enable-tcp \
 	--disable-sndio \
 	--disable-haiku \
-	--disable-soundcloud
+	--disable-soundcloud \
+	--disable-epoll \
+	--disable-signalfd \
+	--disable-eventfd
 
 
 ifeq ($(BUILD_VARIANT),full)


### PR DESCRIPTION
The latest version of mpd doesn't run anymore on a router running Tomato v1.28.0000 MIPSR2-140 K26AC USB, kernel 2.6.22.19. I had to disable epoll, signalfd and eventfd to make it work again.